### PR TITLE
Make imsmanifest.xml creation synchronous instead of async

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,10 +77,6 @@ var buildPackage = function(obj, callback) {
       }
     });
 
-    var manifestFile = fse.createOutputStream(path.join(destination, 'imsmanifest.xml'));
-    manifestFile.write(manifest(schemaVersion, obj));
-    _logSuccess(path.join(destination, 'imsmanifest.xml'));
-
     definitionFileList.forEach(function (file) {
       try {
         fse.copySync(file.source, file.destination);
@@ -90,7 +86,11 @@ var buildPackage = function(obj, callback) {
       }
     });
 
-    callback('Done');
+    fs.writeFile( path.join(destination, 'imsmanifest.xml'), manifest(schemaVersion, obj), (err) => {
+      if (err) return;
+      _logSuccess(path.join(destination, 'imsmanifest.xml'));
+      callback('Done');
+    });
   });
 };
 


### PR DESCRIPTION
I've had some problens with a build script that created a zip file after creating the scorm files.
The fse.write function are async, that resulted in a missing imsmanifest.xml file in the zip file.

This commit fixes this issue.